### PR TITLE
Added simple TLS support 

### DIFF
--- a/mopidy_mqtt/__init__.py
+++ b/mopidy_mqtt/__init__.py
@@ -20,6 +20,7 @@ class Extension(ext.Extension):
 
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
+        schema['tls'] = config.Boolean()
         schema['topic'] = config.String()
         schema['mqtthost'] = config.String()
         schema['mqttport'] = config.Integer()

--- a/mopidy_mqtt/ext.conf
+++ b/mopidy_mqtt/ext.conf
@@ -1,5 +1,6 @@
 [mqtthook]
 enabled = true
+tls = false
 mqtthost = 192.168.0.1
 mqttport = 1883
 topic = home/livingroom/music

--- a/mopidy_mqtt/frontend.py
+++ b/mopidy_mqtt/frontend.py
@@ -22,14 +22,17 @@ class MQTTFrontend(pykka.ThreadingActor, core.CoreListener):
         self.core = core
         self.mqttClient = mqtt.Client(client_id="mopidy-" + str(int(round(time.time() * 1000))), clean_session=True)
         self.mqttClient.on_message = self.mqtt_on_message
-        self.mqttClient.on_connect = self.mqtt_on_connect     
+        self.mqttClient.on_connect = self.mqtt_on_connect
         
         self.config = config['mqtthook']
         host = self.config['mqtthost']
         port = self.config['mqttport']
+        tls = self.config['tls']
         self.stoppedImage = self.config['stoppedimage']
         self.defaultImage = self.config['defaultimage']
         self.topic = self.config['topic']
+        if tls:
+            self.mqttClient.tls_set()
         if self.config['username'] and self.config['password']:
             self.mqttClient.username_pw_set(self.config['username'], password=self.config['password'])
         self.mqttClient.connect_async(host, port, 60)        


### PR DESCRIPTION
Added simple TLS support (default false) assuming system-wide certificates (e.g. when MQTT is behind a reverse proxy with letsencrypt certificate).
